### PR TITLE
fix: use service client for privileged auth

### DIFF
--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -1,5 +1,4 @@
-import { createClient } from '@/lib/supabase/server'
-import { createClient as createServiceClient } from '@/lib/supabase/server'
+import { createClient, createServiceClient } from '@/lib/supabase/server'
 import type { Profile, UserRole } from 'shared'
 
 export async function getCurrentUser() {


### PR DESCRIPTION
## Summary
- fix auth utility to import and use service client correctly for profile creation and other privileged actions

## Testing
- `npm test` *(fails: Cannot find dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68ac303b501c8325b8e9afec93bd4937